### PR TITLE
Pass 404 response gracefully

### DIFF
--- a/lib/sharpie.js
+++ b/lib/sharpie.js
@@ -47,7 +47,12 @@ module.exports = function(defaults) {
 		.on('response', function(response) {
 			if (response.statusCode >= 400) {
 				request.abort();
-				return next();
+				var err = undefined;
+				if (response.statusCode != 404) {
+					err = new Error(response.statusMessage);
+					err.status = response.statusCode;
+				}
+				return next(err);
 			}
 			var contentType = response.headers['content-type'];
 			var typeObj = MediaTyper.parse(contentType);

--- a/lib/sharpie.js
+++ b/lib/sharpie.js
@@ -45,6 +45,10 @@ module.exports = function(defaults) {
 
 		var request = Request(url)
 		.on('response', function(response) {
+			if (response.statusCode == 404) {
+				request.abort();
+				return next();
+			}
 			var contentType = response.headers['content-type'];
 			var typeObj = MediaTyper.parse(contentType);
 			if (typeObj.type != "image") {

--- a/lib/sharpie.js
+++ b/lib/sharpie.js
@@ -45,7 +45,7 @@ module.exports = function(defaults) {
 
 		var request = Request(url)
 		.on('response', function(response) {
-			if (response.statusCode == 404) {
+			if (response.statusCode >= 400) {
 				request.abort();
 				return next();
 			}


### PR DESCRIPTION
Call next() to invoke the applications 404 handler instead of
sending a 400 error to the client.
