### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 sharpie
 =======
 
-A simple express middleware that fetch and resize images using pipes.
+A simple express middleware for resizing images using sharp and pipes
 
 Usage
 -----

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ var sharpie = require('sharpie')({
 	flatten: true
 });
 
-// will get the url through req.param[opts.param]
+// will get the url through req.params[opts.param]
 app.get('/param:url(*)', sharpie);
 // will get the url through req.query[opts.param]
 app.get('/query', sharpie);

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ var sharpie = require('sharpie')({
 	flatten: true
 });
 
-// will get the url through req.params[opts.param]
+// will get the url through req.params[opts.param] – e.g /param/foo.jpg
 app.get('/param:url(*)', sharpie);
-// will get the url through req.query[opts.param]
+// will get the url through req.query[opts.param] – e.g. /query?url=/foo.jpg
 app.get('/query', sharpie);
 
 app.listen();

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ var sharpie = require('sharpie')({
 });
 
 // will get the url through req.param[opts.param]
-app.get('/param/:url', sharpie);
+app.get('/param:url(*)', sharpie);
 // will get the url through req.query[opts.param]
 app.get('/query', sharpie);
 


### PR DESCRIPTION
- Suggest '/param:url(*)' as param-based route path
- Fix a typo in req.params
- Adapt README description to the description in package.json
- README: Add example URLs
